### PR TITLE
Add flag to show the last update time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,6 +30,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
+          showLastUpdateTime: true,
           // Please change this to your repo.
           editUrl: "https://bucket.listws.com"
         },


### PR DESCRIPTION
Now we'll get something like this (without the author's name):

![image](https://user-images.githubusercontent.com/13461315/147515798-3da3efb8-0323-4e89-834f-6b7402330ddc.png)

I didn't tested this locally, I've just followed this: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs